### PR TITLE
E730: using List as a String -- a semantic error

### DIFF
--- a/autoload/buffergator.vim
+++ b/autoload/buffergator.vim
@@ -545,7 +545,7 @@ function! s:NewCatalogViewer(name, title)
           endif
 
           if g:buffergator_show_full_directory_path
-            let l:catalog.parentdir = l:catalog.fullpath
+            let _info.parentdir = _info.fullpath
           endif
 
           call add(l:catalog, _info)

--- a/autoload/buffergator.vim
+++ b/autoload/buffergator.vim
@@ -593,7 +593,7 @@ function! s:NewCatalogViewer(name, title)
             return
         elseif l:bfwn >= 0
             " viewport with buffer exists, but not current
-            execute(l:bfwn . " wincmd w")
+            execute(l:bfwn . "wincmd w")
         else
             " create viewport
             let self.split_mode = s:_get_split_mode()
@@ -806,7 +806,7 @@ function! s:NewCatalogViewer(name, title)
     " window requires it to be split, 1 otherwise
     function! catalog_viewer.is_usable_viewport(winnumber) dict
         "gotta split if theres only one window (i.e. the NERD tree)
-        if winnr("$") ==# 1
+        if !empty(getbufvar(winnumber, "&buftype")) && &buftype == ''
             return 0
         endif
         let oldwinnr = winnr()


### PR DESCRIPTION
1. When triggering the plugin function 
`buffergator#OpenBuffergator`
with \<leader\>b, it failed at line 16 of
`function! catalog_viewer.get_buffers() dict`
with the message: "E730: using List as a String" was printed.
2. Where to open the selected buffer depends on 
`function! catalog_viewer.is_usable_viewport(winnumber) dict`
Changing line 2 from 
`winnr("$") ==# 1`
to
`if !empty(getbufvar(winnumber, "&buftype")) && &buftype == ''`
will make the expected statement.